### PR TITLE
[Suggestion] Attempt to make slide-jumps less overpowered

### DIFF
--- a/src/main/java/io/github/beeebea/fastmove/mixin/PlayerEntityMixin.java
+++ b/src/main/java/io/github/beeebea/fastmove/mixin/PlayerEntityMixin.java
@@ -228,6 +228,9 @@ public abstract class PlayerEntityMixin extends LivingEntity implements IFastPla
                     moveState = MoveState.NONE;
                 }
             }
+            if (lastMoveState == MoveState.SLIDING && moveState != MoveState.SLIDING) {
+                bonusDecay = 0.3; // TODO: Value should be configurable
+            }
 
             if(FastMove.getConfig().wallRunEnabled()) fastmove_WallRun();
 


### PR DESCRIPTION
As of now sliding and then jumping immediately after would preserve the high bonus velocity of the slide.
Chaining multiple slide jumps allows the player to move at a very high speed, with only the cost of hunger as mentioned in issue #24, which I also think is unbalanced.

So I attempted to reduce the bonus speed in this commit by decaying the bonus speed by a lot whenever the player goes from a sliding state to another state.
Ideally the decay amount would be configurable. (It's 0.3 for now)

Original slide jumps:

https://github.com/user-attachments/assets/4b2c37b4-d4d8-480b-97fa-8b4f05eff081

Reduced slide jumps:

https://github.com/user-attachments/assets/abf81bd4-36c7-424b-8924-66b71e8605dd
